### PR TITLE
Add all triggers as body item keys

### DIFF
--- a/src/main/grammars/RpmSpecLexer.flex
+++ b/src/main/grammars/RpmSpecLexer.flex
@@ -83,6 +83,15 @@ FILES_DIRECTIVES=%(doc|config|attr|defattr|dir|docdir|ghost|verify|license|readm
   ^"%pre"                         { return PRE; }
   ^"%preun"                       { return PREUN; }
   ^"%pretrans"                    { return PRETRANS; }
+  ^"%triggerin"                   { return TRIGGERIN; }
+  ^"%triggerun"                   { return TRIGGERUN; }
+  ^"%triggerpostun"               { return TRIGGERPOSTUN; }
+  ^"%filetriggerin"               { return FILETRIGGERIN; }
+  ^"%filetriggerun"               { return FILETRIGGERUN; }
+  ^"%filetriggerpostun"           { return FILETRIGGERPOSTUN; }
+  ^"%transfiletriggerin"          { return TRANSFILETRIGGERIN; }
+  ^"%transfiletriggerun"          { return TRANSFILETRIGGERUN; }
+  ^"%transfiletriggerpostun"      { return TRANSFILETRIGGERPOSTUN; }
   ^"%clean"                       { return CLEAN; }
   ^"%description"                 { return DESCRIPTION; }
   ^"%changelog"                   { return CHANGELOG; }

--- a/src/main/kotlin/com/carbonblack/intellij/rpmspec/RpmSpecSyntaxHighligher.kt
+++ b/src/main/kotlin/com/carbonblack/intellij/rpmspec/RpmSpecSyntaxHighligher.kt
@@ -32,6 +32,15 @@ class RpmSpecSyntaxHighligher : SyntaxHighlighterBase() {
         RpmSpecTypes.PRE -> BODY_ITEM_KEYS
         RpmSpecTypes.PREUN -> BODY_ITEM_KEYS
         RpmSpecTypes.PRETRANS -> BODY_ITEM_KEYS
+        RpmSpecTypes.TRIGGERIN -> BODY_ITEM_KEYS
+        RpmSpecTypes.TRIGGERUN -> BODY_ITEM_KEYS
+        RpmSpecTypes.TRIGGERPOSTUN -> BODY_ITEM_KEYS
+        RpmSpecTypes.FILETRIGGERIN -> BODY_ITEM_KEYS
+        RpmSpecTypes.FILETRIGGERUN -> BODY_ITEM_KEYS
+        RpmSpecTypes.FILETRIGGERPOSTUN -> BODY_ITEM_KEYS
+        RpmSpecTypes.TRANSFILETRIGGERIN -> BODY_ITEM_KEYS
+        RpmSpecTypes.TRANSFILETRIGGERUN -> BODY_ITEM_KEYS
+        RpmSpecTypes.TRANSFILETRIGGERPOSTUN -> BODY_ITEM_KEYS
         RpmSpecTypes.CLEAN -> BODY_ITEM_KEYS
         RpmSpecTypes.DESCRIPTION -> BODY_ITEM_KEYS
         RpmSpecTypes.CHANGELOG -> BODY_ITEM_KEYS


### PR DESCRIPTION
Hi,
    the current implementation  doesn't highlight the triggers body start. This seems a minor annoyance, but since eveything in a Specfile begins with a %, not highlighting the start of block makes everything unreadable.

I've applied the changes to the code with all the missing keys I'm aware of. I have no idea how to test a plugin on intellij, please give it try before merging.

Thank you!

Reference:

[1] [Fedora docs for trigger in/out](http://ftp.rpm.org/api/4.4.2.2/triggers.html)
[2] [RedHat 8 new file triggers](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/packaging_and_distributing_software/new-features-in-rhel-8_packaging-and-distributing-software)