### PR TITLE
Explicitly highlight all the section headers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ detekt {
 }
 
 group = "com.carbonblack"
-version = "2.1.0"
+version = "2.2.0"
 
 tasks.compileJava {
     options.release.set(17)

--- a/src/main/kotlin/com/carbonblack/intellij/rpmspec/psi/RpmSpecMacroElementImpl.kt
+++ b/src/main/kotlin/com/carbonblack/intellij/rpmspec/psi/RpmSpecMacroElementImpl.kt
@@ -5,7 +5,6 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
-import java.util.*
 
 abstract class RpmSpecMacroElementImpl(node: ASTNode) :
     ASTWrapperPsiElement(node), PsiNameIdentifierOwner, RpmSpecMacroElement {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,10 +9,10 @@
 
     <change-notes><![CDATA[
         <html>
-        <b>Changes in version 2.1.0:</b>
+        <b>Changes in version 2.2.0:</b>
         <ul>
-          <li>Build against IntelliJ 2022.3 and Java 17</li>
-          <li>Allow macros such as %autochangelog within the changelog section</li>
+          <li>Build against IntelliJ 2023.2</li>
+          <li>Fix section headers sometimes not being highlighted</li>
         </ul><br>
         </html>
             ]]>


### PR DESCRIPTION
Due to how language injection works these headers can sometimes become un-highlighted. This should fix that by highlighting them in the highlighting annotator and not just the syntax highlighter.

Fixes #17